### PR TITLE
Fix shell script and docker-compose bugs for fresh installs

### DIFF
--- a/AddOnScripts/change_perms.sh
+++ b/AddOnScripts/change_perms.sh
@@ -35,10 +35,10 @@ if [ ! -d "$DIRECTORY" ]; then
 
    echo "Added cronjob to download ISC threat intel daily"
    crontab -l | { cat; echo "# Transfer logs to ELK server"; } | crontab -
-   crontab -l | { cat; echo "0 12 * * * $HOME/scripts/get_iscipintel.sh> /dev/null 2>1&"; } | crontab -
+   crontab -l | { cat; echo "0 12 * * * $HOME/scripts/get_iscipintel.sh> /dev/null 2>&1"; } | crontab -
    echo "Added cronjob to download daily ISC list of researchers"
    crontab -l | { cat; echo "# ISC List of known Researchers"; } | crontab -
-   crontab -l | { cat; echo "0 15 * * * $HOME/scripts/get_researchers.sh > /dev/null 2>1&"; } | crontab -
+   crontab -l | { cat; echo "0 15 * * * $HOME/scripts/get_researchers.sh > /dev/null 2>&1"; } | crontab -
 fi
 
 # Check if the file exist and if it does, change the IP to ELK Server 

--- a/AddOnScripts/get_researchers.sh
+++ b/AddOnScripts/get_researchers.sh
@@ -23,7 +23,7 @@ curl  https://isc.sans.edu/api/threatcategory/research?json -o $HOME/scripts/res
 
 # Parse the JSON file with just the IP and the type
 
-cat ~/research.json | sed 's/},{/}\n{/g' | tr -d '"{}[]' | sed 's/ipv4:\(.*\),added.*type:\(.*\)/"\1": \2/g' > $HOME/DShield-SIEM/logstash/config/scanners.yml
+cat $HOME/scripts/research.json | sed 's/},{/}\n{/g' | tr -d '"{}[]' | sed 's/ipv4:\(.*\),added.*type:\(.*\)/"\1": \2/g' > $HOME/DShield-SIEM/logstash/config/scanners.yml
 
 echo $PASSWORD | sudo -S docker cp $HOME/DShield-SIEM/logstash/config/scanners.yml logstash:/usr/share/logstash/config
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -477,6 +477,7 @@ services:
       co.elastic.logs/module: heartbeat
     user: root
     restart: unless-stopped
+    command: ["heartbeat", "-e", "--strict.perms=false"]
     configs:
       - source: hb_config
         target: /usr/share/heartbeat/heartbeat.yml


### PR DESCRIPTION
Three small bugs that cause setup failures on a fresh install:

1. change_perms.sh — broken crontab redirect syntax (2>1& → 2>&1)
Both cron entries for get_iscipintel.sh and get_researchers.sh had a malformed stderr redirect. 2>1& creates a file named 1 and backgrounds the process rather than redirecting stderr to stdout. This causes silent failures — the jobs appear to install correctly but errors are never captured.
2. get_researchers.sh — hardcoded ~/research.json path
The script downloads research.json to $HOME/scripts/research.json but then reads it from ~/research.json (repo root). Changed to $HOME/scripts/research.json to match where the file is actually written.
3. docker-compose.yml — heartbeat fails to start due to strict permission check
Heartbeat refuses to start when its config file is owned by root but run as a different user. Added --strict.perms=false to the heartbeat command so the service starts reliably without requiring manual ownership fixes after every update.

Testing

- Run change_perms.sh and verify crontab -l shows 2>&1 on both cron lines
- Confirm get_researchers.sh reads and processes $HOME/scripts/research.json correctly
- Bring up the stack with docker compose up -d and confirm heartbeat reaches running state without ownership errors in the logs

Impact

Low risk — no logic changes, no new dependencies. All three are corrections to existing behavior.